### PR TITLE
Add loan detail/repayment history view

### DIFF
--- a/UI/loan.html
+++ b/UI/loan.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Quick Credit-Loan details</title>
+    <link href="static/styles/main.css", rel="stylesheet", type="text/css">
+    <link href="static/styles/media.css", rel="stylesheet", type="text/css">
+  </head>
+  <!--onload function selects elements applicable to home page from template elements-->
+  <body id='user_profile_page' onload = "showPage(['user'], ['auth', 'menu'])">
+    <!--the page template dynamically written from script indicated-->
+    <script src='static/scripts/template.js'></script>
+    <!--page specific content written from script indicated-->
+    <script src='static/scripts/loan.js'></script>
+    <!--main script for manipulating page behaviour-->
+    <script src="static/scripts/main.js"></script>
+  </body>
+</html>

--- a/UI/static/scripts/loan.js
+++ b/UI/static/scripts/loan.js
@@ -1,0 +1,37 @@
+// loan application page
+document.write(
+`<div id="main">\
+<h1 id='username'>Loan ID 18050630007</h1><hr>\
+<div id="main_main">\
+<h3><div id='actions' class='actions hidden'><div class='admin'></div><div class='admin'></div><div class='admin'></div></div>Loan Transaction Log <span>- Anguandia Mike</span></h3><hr>\
+<ul class="list">\
+<li>\
+  <span class='blue'>Cr:</span>\
+  <span>transaction id - 18050630008;</span>\
+  <span class='blue'>$30000;</span>\
+  <span>date: 15/12/2018</span>\
+</li>\
+<li>\
+  <span class='green'>Dr:</span>\
+  <span>transaction id - 18070230301;</span>\
+  <span class='green'>$01000;</span>\
+  <span>date: 30/01/2019</span>\
+</li>\
+<li>\
+  <span class='green'>Dr:</span>\
+  <span>transaction id - 18070630001;</span>\
+  <span class='green'>$01200;</span>\
+  <span>date: 28/02/2019</span>\
+</li>\
+<li>\
+  <span class='green'>Dr:</span>\
+  <span>transaction id - 18070630001;</span>\
+  <span class='green'>$01000;</span>\
+  <span>date: 31/03/2019</span>\
+</li>\
+<p><span class='blue'>Current Balance: </span><span class='red'>$26800</span></p>
+</ul>\
+</div>\
+<script src='static/scripts/user.js'></script>\
+</div>\
+`);

--- a/UI/static/scripts/main.js
+++ b/UI/static/scripts/main.js
@@ -10,6 +10,7 @@ function showPage(required, parents){
         var elements = cont.querySelectorAll('*');
         // document.getElementById(parent).style.display = 'block';
         cont.style.display = 'block';
+        console.log(cont);
         for(var element of elements){
             //get an array of classnames of each child element
             if(element.hasAttribute('class')){var classes = element.getAttribute('class');
@@ -28,7 +29,7 @@ function showPage(required, parents){
                         // call validation setting function for required input fields; all have two children each; the input and the asterisk span marking the field as required
                         addValidation(element);
                     } else {
-                        element.style.display = 'initial';
+                        element.style.display = 'inherit';
                     }
                 }
             } else {

--- a/UI/static/scripts/template.js
+++ b/UI/static/scripts/template.js
@@ -26,11 +26,11 @@ document.write(
         <a href='info.html' class='universal' id='info'>Loan info</a>\
         <a href='schemes.html' class='universal' id='shemes'>Loan schemes</a>\
         <a href='apply.html' class='user' id='apply'>Apply for loan</a>\
-        <a href='apply.html' class='user' id='view'>View repayments</a>\
-        <a href='loans.html' class='admin' id='loans'>Loan Applications</a>\
+        <a href='loan.html' class='user' id='view'>View repayment history</a>\
+        <a href='loans.html' class='admin' id='loans'>Loan applications</a>\
         <a href='current.html' class='admin' id='current'>Current loans</a>\
         <a href='repaid.html' class='admin' id='repaid'>Repaid loans</a>\
-        <a href='detsils.html' class='user admin' id='details'>Loan detsils</a>\
+        <a href='loan.html' class='user admin' id='details'>Loan detsils</a>\
         <a href='approve.html' class='admin' id='approve'>Approve loan</a>\
         <a href='debit.html' class='admin' id='debit'>Debit loan</a>\
         <a href='users.html' class='admin' id='users'>Clients</a>\

--- a/UI/static/styles/main.css
+++ b/UI/static/styles/main.css
@@ -338,9 +338,10 @@ button:active{
 .list{
     position: relative;
     width: 90%;
-    margin: 0%;
+    padding: 1% 0;
     list-style: none;
     background: mintcream;
+    margin: 0% auto 0 auto;
 }
 
 /* remove unerlining from loan names and ids */
@@ -348,20 +349,22 @@ button:active{
     text-decoration: none;
 }
 
-/* higlight items on select */
+hr{
+    margin: 0%
+}
+
+/* improve visual experience by alternatin the background of scuccessive list items */
+.list li:nth-child(even){
+    background-color: lightgray;
+}
+
+/* higlight items on hover. Should come after the altenating background declaration to take effect on rows with a background */
 .list li:hover{
     background: rgb(200, 134, 216);
     cursor: pointer;
 }
 
-hr{
-    margin: 0%
-}
-
-.list li:nth-child(even){
-    background-color: lightgray;
-}
-
+/* search button */
 .search{
     background: steelblue;
     padding: .5%;
@@ -396,23 +399,18 @@ hr{
     display: inline-block;
     width: 95%;
     margin: 0% auto;
-    /* width: inherit; */
     border-radius: 10px;
     border-width: .7px;
 }
 
 #loanform fieldset label{
     display: inline-block;
-    /* width: 38ch; */
     width: 45%;
     text-align: left;
     margin: .1% 2% 0% 2%;
-    /* width: 100%; */
 }
 
-
 #loanform input{
-    /* display: inline-block; */
     border: transparent;
     border-bottom: solid 1px;
     width: 100%;
@@ -448,4 +446,46 @@ hr{
 /* align buttons inthe middle of the table width span */
 #btns{
     text-align: center;
+}
+
+/* loan detail page styles */
+/* display installments in green font */
+.green{
+    color: green;
+}
+
+/* display outsanding balance in red font */
+.red{
+    color: red;
+}
+
+/* display initial amount in blue */
+.blue{
+    color: blue;
+}
+
+/* style page heading */
+#main_main h3{
+    text-align: center;
+    font-weight: 100;
+}
+
+/* general font for section */
+#main_main{
+    font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+}
+
+/* detail page action menu icon-will only be used when admin viewing loan detail to verify user, approve/reject loan credit or debit account */
+#actions{
+    float: left;
+    margin: 0 2%;
+}
+
+#actions div{
+    height: 2px;
+    width: 20px;
+    background: black;
+    margin: 2px;
+    opacity: .8;
+    content: '';
 }


### PR DESCRIPTION
#### What does this PR do?
Add a dummy loan detail record feature broken as:
- Add the script to write the loan detail so may be reused for both
client and admin view pages
- Modify the showPage function in the main script file to be able to
display the associated sub-menu icon for the admin loan detail view pages
- Add the HTML frame to hold the resulting page and call other display
functions
- Add CSS for the page
- Update links references of associated menu items in the template
script to the created page

#### Description of Task to be completed
The user should be able to view a loan's details thus:
- The initial amount credited to their account
- Each installment repaid
- The current outstanding balance each displayed with:
  - The date, amount, type(Dr for loan repayments and Cr for loan credited
  to client's account, id(receipt number) of the transaction
  - Key fields displayed in different colors

#### How should this be manually tested?
To get to the loan details page, either
- Navigate to https://anguandia.github.io/quickCredit/, login then click the view repayment history or
- Clone this repo and open the loan.html file in your browser

You will see a Demo load record detail

#### What are the relevant pivotal tracker stories?
[#165489489 #165489571]