### PR TITLE
fix class misnomer

### DIFF
--- a/UI/static/scripts/loandetail.js
+++ b/UI/static/scripts/loandetail.js
@@ -36,8 +36,8 @@ document.write(`<div id='main'>
     </dl><hr>
     <script src='static/scripts/log.js'></script>
     <div>
-      <button id='rejectuser' class='_red white verify_loan' onclick="approve('user verification not done!', 'yellow', 'red')">Reject</button>
-      <button id='verify' class='_green white verify_loan' onclick="approve('user verified')">Verify</button>
+      <button id='rejectuser' class='_red white verify_user' onclick="approve('user verification not done!', 'yellow', 'red')">Reject</button>
+      <button id='verify' class='_green white verify_user' onclick="approve('user verified')">Verify</button>
       <button id='reject' class='_red white approve_loan' onclick="approve('loan request rejected', 'red')">Reject</button>
       <button id='approve' class='_green white approve_loan' onclick="approve('loan approved!')">Approve</button>
       <button id='post' class='_green white debit_loan' onclick="approve('account debited')">Post Payment</button>


### PR DESCRIPTION
#### What does this PR do
Correct verify user buttons' class name to verify_user from the previous verify_loan

#### How should this be manually tested?
- Login as admin and select verify user
- Select a user from the page displayed or enter a user id in the search box and hit enter
- You should now see the verify and reject buttons

#### Background context
The action buttons were not displayed