### PR TITLE
Modify user profile page to dashboard tabs

### DIFF
--- a/UI/current.html
+++ b/UI/current.html
@@ -7,7 +7,7 @@
     <link href="static/styles/media.css", rel="stylesheet", type="text/css">
   </head>
   <!--onload function redirects to loan listing on client profile page-->
-  <body id='loan_application_page' onload = "loadSelection('Current', 'All Current Loans', '?loan_180524=view_loan')">
+  <body id='loan_application_page' onload = "loadSelection('Current', 'All Current Loans', '?a_loan_180524=view_loan')">
     <!--main script for manipulating page behaviour-->
     <script src="static/scripts/main.js"></script>
   </body>

--- a/UI/home.html
+++ b/UI/home.html
@@ -2,12 +2,16 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Quick Credit-Applications</title>
+    <title>Quick Credit-User Home</title>
     <link href="static/styles/main.css", rel="stylesheet", type="text/css">
     <link href="static/styles/media.css", rel="stylesheet", type="text/css">
   </head>
   <!--onload function selects elements applicable to home page from template elements-->
-  <body id='admin_profile_page' onload = "loadSelection('Draft', 'All Loan Applications', '?a_loan_180524=View_loan')">
+  <body id='user_profile_page' onload = "showPage(['user'], ['auth', 'menu'])">
+    <!--the page template dynamically written from script indicated-->
+    <script src='static/scripts/template.js'></script>
+    <!--page specific content written from script indicated-->
+    <script src='static/scripts/home.js'></script>
     <!--main script for manipulating page behaviour-->
     <script src="static/scripts/main.js"></script>
   </body>

--- a/UI/repaid.html
+++ b/UI/repaid.html
@@ -7,7 +7,7 @@
     <link href="static/styles/media.css", rel="stylesheet", type="text/css">
   </head>
   <!--onload function redirects to loan listing on client profile page-->
-  <body id='loan_application_page' onload = "loadSelection('Completed', 'All Fully Serviced Loans', '?loan_180524=view_loan')">
+  <body id='loan_application_page' onload = "loadSelection('Completed', 'All Fully Serviced Loans', '?a_loan_180524=view_loan')">
     <!--main script for manipulating page behaviour-->
     <script src="static/scripts/main.js"></script>
   </body>

--- a/UI/static/scripts/admin.js
+++ b/UI/static/scripts/admin.js
@@ -19,13 +19,13 @@ document.write(
       </label>
     </div><hr>\
     <button class='dashboard _yellow green' id='new_user' onclick="loadSelection('Not Verified',  'New Users')"><p>*New Users<span>10</span></p></button>\
-    <button class='dashboard _lightgreen navy' id='Draft' onclick='loadSelection("Draft","", "?loan_180524=View_loan")'><p>*New loans<span>6</span></p></button>\
-    <button class='dashboard _lightblue navy' id='Verified' onclick='loadSelection("Verified","","?loan_180524=View_loan")'><p>Pending Approval<span>11</span></p></button>\
-    <button class='dashboard _aliceblue' id='Approved' onclick='loadSelection("Approved", "","?loan_180524=View_loan")'><p>Pending Credit<span>18</span></p></button>\
-    <button class='dashboard _yellow red' id='Rejected' onclick='loadSelection("Rejected", "","?loan_180524=View_loan")'><p>Rejected loan applications<span>10</span></p></button>\
-    <button class='dashboard _navy white' id='Current' onclick='loadSelection("Current", "","?loan_180524=view_loan")'><p>Running loans<span>10</span></p></button>\
-    <button class='dashboard _red white' id='Overdue' onclick='loadSelection("Overdue", "","?loan_180524=view_loan")'><p>Loans overdue<span>10</span></p></button>\
-    <button class='dashboard _green white' id='Completed' onclick='loadSelection("Completed", "","?loan_180524=view_loan")'><p>Completed<span>10</span></p></button>\
+    <button class='dashboard _lightgreen navy' id='Draft' onclick='loadSelection("Draft","", "?a_loan_180524=View_loan")'><p>*New loans<span>6</span></p></button>\
+    <button class='dashboard _lightblue navy' id='Verified' onclick='loadSelection("Verified","","?a_loan_180524=View_loan")'><p>Pending Approval<span>11</span></p></button>\
+    <button class='dashboard _aliceblue' id='Approved' onclick='loadSelection("Approved", "","?a_loan_180524=View_loan")'><p>Pending Credit<span>18</span></p></button>\
+    <button class='dashboard _yellow red' id='Rejected' onclick='loadSelection("Rejected", "","?a_loan_180524=View_loan")'><p>Rejected loan applications<span>10</span></p></button>\
+    <button class='dashboard _navy white' id='Current' onclick='loadSelection("Current", "","?a_loan_180524=view_loan")'><p>Running loans<span>10</span></p></button>\
+    <button class='dashboard _red white' id='Overdue' onclick='loadSelection("Overdue", "","?a_loan_180524=view_loan")'><p>Loans overdue<span>10</span></p></button>\
+    <button class='dashboard _green white' id='Completed' onclick='loadSelection("Completed", "","?a_loan_180524=view_loan")'><p>Completed<span>10</span></p></button>\
     </div>\
     <script src='static/scripts/user.js'></script>\
     </div>\

--- a/UI/static/scripts/auth.js
+++ b/UI/static/scripts/auth.js
@@ -1,6 +1,6 @@
 document.write(
 `<div id='main'>\
-  <form id='authform' class='auth' action='client.html'>\
+  <form id='authform' class='auth' action='home.html'>\
     <label class='signup'>first name<span>*</span>\
       <input type='text' name='first_name' id='first'\
       placeholder='first name'></input>\

--- a/UI/static/scripts/client.js
+++ b/UI/static/scripts/client.js
@@ -7,7 +7,7 @@ document.write(
 placeholder="enter loan id to search">\
 <tab class="search"><a href="detail.html${window.location.search}">Select</a></tab>\
 <div id="controls">\
-  <label class='user hidden'>Sort by:
+  <label class='universal'>Sort by:
   <select onchange='selectSort(event)'>\
   <option>--select--</option>\
   <option>Name</option>\

--- a/UI/static/scripts/home.js
+++ b/UI/static/scripts/home.js
@@ -7,5 +7,6 @@ document.write(
     <button class='dashboard _lightgreen navy' id='Draft' oclick='loadSelection("Draft"," Active Loan - Anguandia Mike", "?u_loan_180524=View_loan")'><p><a href=detail.html?u_loan_180524=view_loan style='text-decoration:none; color:navy'>*Current loan<span>26% Paid</span></a></p></button>\
     <button class='dashboard _green white' id='Completed' onclick='loadSelection("Completed", "","?u_loan_180524=view_loan")'><p>Completed<span>10</span></p></button>\
     </div>\
+    <script src='static/scripts/user.js'></script>\
     </div>\
     `);

--- a/UI/static/scripts/home.js
+++ b/UI/static/scripts/home.js
@@ -1,0 +1,11 @@
+// loan application page
+document.write(
+    `<div id="main">\
+    <h1 id='username'>Admin Mike</h1><hr>\
+    <div id="main_main">\
+    <h3 class='home'>Anguandia-Personal Dashboard</h3><hr>\
+    <button class='dashboard _lightgreen navy' id='Draft' oclick='loadSelection("Draft"," Active Loan - Anguandia Mike", "?u_loan_180524=View_loan")'><p><a href=detail.html?u_loan_180524=view_loan style='text-decoration:none; color:navy'>*Current loan<span>26% Paid</span></a></p></button>\
+    <button class='dashboard _green white' id='Completed' onclick='loadSelection("Completed", "","?u_loan_180524=view_loan")'><p>Completed<span>10</span></p></button>\
+    </div>\
+    </div>\
+    `);

--- a/UI/static/scripts/loandetail.js
+++ b/UI/static/scripts/loandetail.js
@@ -35,7 +35,7 @@ document.write(`<div id='main'>
       <dt>Total Amount Due(USD): <span id='value'>108000</span></dt>
     </dl><hr>
     <script src='static/scripts/log.js'></script>
-    <div>
+    <div class='admin'>
       <button id='rejectuser' class='_red white verify_user' onclick="approve('user verification not done!', 'yellow', 'red')">Reject</button>
       <button id='verify' class='_green white verify_user' onclick="approve('user verified')">Verify</button>
       <button id='reject' class='_red white approve_loan' onclick="approve('loan request rejected', 'red')">Reject</button>

--- a/UI/static/scripts/log.js
+++ b/UI/static/scripts/log.js
@@ -1,28 +1,28 @@
 document.write(`
-<h3 class='user debit_loan view_loan'>Loan Transaction Log - Anguandia Mike</h3><hr class='user debit view'>\
-<ul id='log' class="list user view_loan debit_loan">\
+<h3 class='user debit_loan view_loan'>Loan Transaction Log - Anguandia Mike</h3><hr class='user debit_loan view_loan'>\
+<ul id='log' class="list view_loan debit_loan">\
 <li>\
   <span class='blue universal'>Cr:</span>\
   <span>transaction id - 18050630008;</span>\
-  <span class='blue'>$30000;</span>\
+  <span class='blue universal'>$30000;</span>\
   <span>date: 15/12/2018</span>\
 </li>\
 <li>\
   <span class='green universal'>Dr:</span>\
   <span>transaction id - 18070230301;</span>\
-  <span class='green'>$01000;</span>\
+  <span class='green universal'>$01000;</span>\
   <span>date: 30/01/2019</span>\
 </li>\
 <li>\
   <span class='green universal'>Dr:</span>\
   <span>transaction id - 18070630001;</span>\
-  <span class='green'>$01200;</span>\
+  <span class='green universal'>$01200;</span>\
   <span>date: 28/02/2019</span>\
 </li>\
 <li>\
   <span class='green universal'>Dr:</span>\
   <span>transaction id - 18070630001;</span>\
-  <span class='green'>$01000;</span>\
+  <span class='green universal'>$01000;</span>\
   <span>date: 31/03/2019</span>\
 </li>\
 <p><span class='blue'>Current Balance: </span><span class='red'>$26800</span></p>

--- a/UI/static/scripts/main.js
+++ b/UI/static/scripts/main.js
@@ -91,12 +91,15 @@ addValidation = function(element){
     inp.setAttribute('oninvalid', `this.setCustomValidity('${element.textContent} can not be empty')`);
 };
 
-//redirect to user profilepage onsubmit signin/signup
+//redirect to user profile page onsubmit signin/signup
 //only for demonstration purpose
 function redirect(){
+    var url;
     var role = document.getElementById('role');
     var form = document.querySelector('form');
-    form.setAttribute('action', `${role.value}.html`);
+    if(role.value == 'Admin'){
+        form.setAttribute('action', 'Admin.html');
+    }
 }
 
 // sort lists(loans/users)
@@ -210,6 +213,8 @@ function checkRedirect(){
         var j = localStorage.getItem('j');
         filterData(j, status);
         localStorage.clear('*');
+    }
+    if(window.location.search.slice(1,2)=='a'){
         showPage(['admin'], ['auth', 'menu', 'controls']);
     } else {
         showPage(['user'], ['auth', 'menu', 'controls']);
@@ -231,16 +236,30 @@ function approve(resp, bg='green', color='white'){
 // decode url query string to get admin function to execute on loan detail: verify, debit, view or approve
 function decodeQuery(){
     // get query
-    var query = window.location.search
+    var query = window.location.search;
+    console.log(query.slice(0,1));
     // extract required class to be selectively loaded and page title from query string
     var key = query.slice(query.indexOf('=')+1);
     var heading = document.querySelector('h1');
     var sub = document.querySelector('h3');
-    var raw = query.slice(1, query.indexOf('='));
+    var raw = query.slice(3, query.indexOf('='));
     // constitute page title
     var title = raw.replace('_', ' ');
     // constitute page purpose sub-heading
     heading.innerHTML = title;
     sub.innerHTML = key.replace('_', ' ') || 'view user';
-    showPage(['admin', key], ['auth', 'menu', 'loandetail'])
+    if(query.slice(1, 2) == 'u'){
+        showPage(['user', key], ['auth', 'menu', 'loandetail']);
+    } else {
+        showPage(['admin', key], ['auth', 'menu', 'loandetail']);
+    }
+}
+
+function checkRole(){
+    var query, title, cl, role;
+    query = window.location.search;
+    title = query.slice(3, query.indexOf('='));
+    cl = query.slice(query.indexOf('=') + 1);
+    role = query.slice(1, 2);
+    if(role == 'u'){}
 }

--- a/UI/static/scripts/template.js
+++ b/UI/static/scripts/template.js
@@ -26,16 +26,16 @@ document.write(
         <a href='info.html' class='universal' id='info'>Loan info</a>\
         <a href='schemes.html' class='universal' id='shemes'>Loan schemes</a>\
         <a href='apply.html' class='user' id='apply'>Apply for loan</a>\
-        <a href='loan.html' class='user' id='view'>View repayment history</a>\
-        <a href='loans.html?loan_180524=View_loan' class='admin' id='loans'>Loan applications</a>\
-        <a href='current.html?loan_180524=view_loan' class='admin' id='current'>Current loans</a>\
-        <a href='repaid.html?loan_180524=view_loan' class='admin' id='repaid'>Repaid loans</a>\
-        <a href='client.html?loan_180524=view_loan' class='admin' id='details'>Loan details</a>\
-        <a href='client.html?loan_180524=approve_loan' class='admin' id='approve_loan'>Approve loan</a>\
-        <a href='client.html?loan_180524=debit_loan' class='admin' id='debit_loan'>Debit loan</a>\
-        <a href='users.html?user_1090524=view_user' class='admin' id='users'>Clients</a>\
-        <a href='users.html?client_190118=' class='admin' id='user'>Client Details</a>\
-        <a href='client.html?client_190118=verify_user' class='admin' id='verify_user'>Verify Client</a>\
+        <a href='loan.html?u_' class='user' id='view'>View repayment history</a>\
+        <a href='loans.html?a_loan_180524=View_loan' class='admin' id='loans'>Loan applications</a>\
+        <a href='current.html?a_loan_180524=view_loan' class='admin' id='current'>Current loans</a>\
+        <a href='repaid.html?a_loan_180524=view_loan' class='admin' id='repaid'>Repaid loans</a>\
+        <a href='client.html?a_loan_180524=view_loan' class='admin' id='details'>Loan details</a>\
+        <a href='client.html?a_loan_180524=approve_loan' class='admin' id='approve_loan'>Approve loan</a>\
+        <a href='client.html?a_loan_180524=debit_loan' class='admin' id='debit_loan'>Debit loan</a>\
+        <a href='users.html?a_user_1090524=view_user' class='admin' id='users'>Clients</a>\
+        <a href='users.html?a_client_190118=' class='admin' id='user'>Client Details</a>\
+        <a href='client.html?a_client_190118=verify_user' class='admin' id='verify_user'>Verify Client</a>\
       </div>\
       <div id='iconcontainer'>\
       <div class='iconrow'>\

--- a/UI/static/scripts/users.js
+++ b/UI/static/scripts/users.js
@@ -17,105 +17,105 @@ document.write(
     <ul class="list">\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Anguandia Mike</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Anguandia Mike</span>\
       <span>18050630007</span></a>\
       <span>anguamike@yahoo.com</span>\
       <span class='lightgreen'>Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Benjamin Franklin</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Benjamin Franklin</span>\
       <span>18070230301</span></a>\
       <span>benja@gmail.com</span>\
       <span class='lightgreen'>Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Isaac Asimov</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Isaac Asimov</span>\
       <span>18070630001</span></a>\
       <span>asim@hotmail.com</span>\
       <span class='lightgreen'>Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Fadil Rajab</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Fadil Rajab</span>\
       <span>18070630001</span></a>\
       <span>fadhil.rajab@mail.com</span>\
       <span class='lightgreen'>Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Peter Simon</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Peter Simon</span>\
       <span>18070630001</span></a>\
       <span>simo@kj.com</span>\
       <span class='green'>Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Famin Pierr</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Famin Pierr</span>\
       <span>10070630001</span></a>\
       <span>famin@netpipper.com</span>\
       <span class='green'>Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Clera Serah</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Clera Serah</span>\
       <span>12120630001</span></a>\
       <span>flera@mail.com</span>\
       <span class='red' id='Not Verified'>Not Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Zadoch Simon</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Zadoch Simon</span>\
       <span>0807063000</span></a>\
       <span>zad@mail.com</span>\
       <span class='red' id='Not Verified'>Not Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Os pa mali</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Os pa mali</span>\
       <span>15070630301</span></a>\
       <span>ospamil@ymail.com</span>\
       <span class='navy'>Owing</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Bonny Musa</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Bonny Musa</span>\
       <span>17070630001</span></a>\
       <span>mier@gmail.com</span>\
       <span class='red' id='Not Verified'>Not Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Tolea Ofin</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Tolea Ofin</span>\
       <span>18070630001</span></a>\
       <span>toto@mail.com</span>\
       <span class='red' id='Not Verified'>Not Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Karim Peter</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Karim Peter</span>\
       <span>18070230301</span></a>\
       <span>karim@example.com</span>\
       <span class='yellow'>Overdue</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Boran Siraj</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Boran Siraj</span>\
       <span>18070630001</span></a>\
       <span>-----</span>\
       <span class='lightblue'>Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Fiona Paul</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Fiona Paul</span>\
       <span>18070630001</span></a>\
       <span>kuku200@mail.com</span>\
       <span class='lightblue'>Verified</span>\
     </li>\
     <li>\
       <input type='checkbox'></input>\
-      <a href='user.html?user_101029=view_User'><span class='name'>Douglas Marie</span>\
+      <a href='user.html?a_user_101029=view_User'><span class='name'>Douglas Marie</span>\
       <span>18070630001</span></a>\
       <span>no mail</span>\
       <span class='green'>Verified</span>\


### PR DESCRIPTION
Change User profile page to display dashboard tabs

#### Description of Task to be completed?

Sort a range of wrong display and account mingling issues as well as add a more pertinent client home page as broken herein:
- Remove loan collection from client profile page and replace with the current loan and archive dashboard tabs; the current loan tab displaying the percentage paid, and onclick the whole loan detail while the archive tab shows the number of loans completed(archived) and on click, a listingof the archived loans, selection of one, its details.
Details:
  - Add new HTML page for user profile and associated script for writing
     its content(as to be able to reuse template)
  - Rectify display of wrong account-type menu:
  - Prepend a_ and u_ as user role identifiers to every URL for
     redirects and anchor hrefs
  - Point client login to the new home page(modify the redirect function
     responsible for getting the default page on sign-in/up) in the main
     script file
  - Modify pre-existing page display and forwarding functions to extract
     user role from the url query string and provide appropriate arguments to
     page load functions(checkRedirect and decodeQuery)
- Correct page titles and functions especially for detail view pages and
    search/collections display pages
  - Streamline page title purpose encoding int URL query and decoding and integrate with role encoding

#### How should this be manually tested?

  - Visit https://anguandia.github.io/quickCredit/ or clone this repo and
    open signup.html
  - Sign in as admin and client in turn and each time testing out every
    feature

    [finishes #165663329 #165656218]