### PR TITLE
Add rationale to page and item variable values

### DIFF
--- a/UI/static/scripts/admin.js
+++ b/UI/static/scripts/admin.js
@@ -1,7 +1,7 @@
 // loan application page
 document.write(
     `<div id="main">\
-    <h1 id='username'>Admin Mike</h1><hr>\
+    <h1 id='username'>${localStorage.getItem('current user')}</h1><hr>\
     <div id="main_main">\
     <input type="text" name="loan" class="searchbox" onkeyup="filterData(1)"\
     placeholder="enter loan id to search">\

--- a/UI/static/scripts/auth.js
+++ b/UI/static/scripts/auth.js
@@ -31,8 +31,9 @@ document.write(
       <input type='password' id='confirm_password' placeholder='confirm\ password'></input>\
     </label>\
     <label class='signin'>Signin as:\
-      <select id='role' onchange='redirect()'>\
-        <option>client</option>\
+      <select id='role' onchange='redirect()' required oninvalid='this.setCustomValidity("please select user type")'>\
+        <option value=''>--select--</option>\
+        <option>Client</option>\
         <option>Admin</option>\
       </select>\
     </label>\

--- a/UI/static/scripts/client.js
+++ b/UI/static/scripts/client.js
@@ -27,110 +27,110 @@ placeholder="enter loan id to search">\
   </label>
 </div><hr>\
 <ul class="list">\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Anguandia Mike</span>\
   <span>18050630007</span></a>\
   <span>$30000</span>\
-  <span class='lightgreen'>Draft</span>\
+  <span id='status' class='lightgreen'>Draft</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
-  <a href='detail.html${window.location.search}'><span class='name'>Benjamin Franklin</span>\
+  <a href='detail.html${window.location.search}'><span class='name'>${localStorage.getItem('role')=='Client'?localStorage.getItem('current user'): 'Benjamin Franklin'}</span>\
   <span>18070230301</span></a>\
   <span>$75000</span>\
-  <span class='green'>Completed</span>\
+  <span id='status' class='green'>Completed</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Isaac Asimov</span>\
   <span>18070630001</span></a>\
   <span>$91000</span>\
-  <span class='red'>Rejected</span>\
+  <span id='status' class='red'>Rejected</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Fadil Rajab</span>\
   <span>18070630001</span></a>\
   <span>$55000</span>\
-  <span class='lightgreen'>Draft</span>\
+  <span id='status' class='lightgreen'>Draft</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
-  <a href='detail.html${window.location.search}'><span class='name'>Peter Simon</span>\
+  <a href='detail.html${window.location.search}'><span class='name'>${localStorage.getItem('role')=='Client'?localStorage.getItem('current user'): 'Peter Simon'}</span>\
   <span>18070630001</span></a>\
   <span>$850000</span>\
-  <span class='green'>Completed</span>\
+  <span id='status' class='green'>Completed</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
-  <a href='detail.html${window.location.search}'><span class='name'>Famin Pierr</span>\
-  <span>10070630001</span></a>\
+  <a href='detail.html${window.location.search}'><span class='name'>${localStorage.getItem('role')=='Client'?localStorage.getItem('current user'): 'Famin Pierr'}</span>\
+  <span>10070630009</span></a>\
   <span>$58000</span>\
-  <span class='green'>Completed</span>\
+  <span id='status' class='green'>Completed</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Clera Serah</span>\
   <span>12120630001</span></a>\
   <span>$110000</span>\
-  <span class='red'>Rejected</span>\
+  <span id='status' class='red'>Rejected</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Zadoch Simon</span>\
   <span>0807063000</span></a>\
   <span>$18000</span>\
-  <span class='red'>Rejected</span>\
+  <span id='status' class='red'>Rejected</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Os pa mali</span>\
   <span>15070630301</span></a>\
   <span>$32000</span>\
-  <span class='navy'>Current</span>\
+  <span id='status' class='navy'>Current</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Bonny Musa</span>\
   <span>17070630001</span></a>\
   <span>$2400</span>\
-  <span class='red'>Rejected</span>\
+  <span id='status' class='red'>Rejected</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Tolea Ofin</span>\
   <span>18070630001</span></a>\
   <span>$55500</span>\
-  <span class='red'>Rejected</span>\
+  <span id='status' class='red'>Rejected</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Karim Peter</span>\
   <span>18070230301</span></a>\
   <span>$19000</span>\
-  <span class='yellow'>Overdue</span>\
+  <span id='status' class='yellow'>Overdue</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Boran Siraj</span>\
   <span>18070630001</span></a>\
   <span>$9900</span>\
-  <span class='lightblue'>Verified</span>\
+  <span id='status' class='lightblue'>Verified</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Fiona Paul</span>\
   <span>18070630001</span></a>\
   <span>$660000</span>\
-  <span class='lightblue'>Verified</span>\
+  <span id='status' class='lightblue'>Verified</span>\
 </li>\
-<li>\
+<li onclick='setClient(this)'>\
   <input type='checkbox'></input>\
   <a href='detail.html${window.location.search}'><span class='name'>Douglas Marie</span>\
   <span>18070630001</span></a>\
   <span>$2100</span>\
-  <span class='aliceblue'>Approved</span>\
+  <span id='status' class='aliceblue'>Approved</span>\
 </li>\
 </ul>\
 </div>\

--- a/UI/static/scripts/home.js
+++ b/UI/static/scripts/home.js
@@ -1,11 +1,11 @@
 // loan application page
 document.write(
     `<div id="main">\
-    <h1 id='username'>Admin Mike</h1><hr>\
+    <h1 id='username'>${localStorage.getItem('current user')}</h1><hr>\
     <div id="main_main">\
-    <h3 class='home'>Anguandia-Personal Dashboard</h3><hr>\
-    <button class='dashboard _lightgreen navy' id='Draft' oclick='loadSelection("Draft"," Active Loan - Anguandia Mike", "?u_loan_180524=View_loan")'><p><a href=detail.html?u_loan_180524=view_loan style='text-decoration:none; color:navy'>*Current loan<span>26% Paid</span></a></p></button>\
-    <button class='dashboard _green white' id='Completed' onclick='loadSelection("Completed", "","?u_loan_180524=view_loan")'><p>Completed<span>10</span></p></button>\
+    <h3 class='home'>${localStorage.getItem('current user')}-Personal Dashboard</h3><hr>\
+    <button class='dashboard _lightgreen navy' id='Draft' onclick='loadOwn()'><p><a href=detail.html?u_loan_180524=view_loan style='text-decoration:none; color:navy'>*Current loan<span>26% Paid</span></a></p></button>\
+    <button class='dashboard _green white' id='Completed' onclick='loadOwnHistory()'><p>Completed<span>10</span></p></button>\
     </div>\
     <script src='static/scripts/user.js'></script>\
     </div>\

--- a/UI/static/scripts/loandetail.js
+++ b/UI/static/scripts/loandetail.js
@@ -7,10 +7,10 @@ document.write(`<div id='main'>
       <h4>Client Particulars</h4>
       <div id='pic'><img src='static/images/Penguins.jpg' alt='photo' width='64' height='64'></img></div>
       <dt>Client Id: <span>910536</span></dt>
-      <dt>Name: <span>Anguandia Mike</span></dt>
+      <dt>Name: <span>${(localStorage.getItem('role')=='Client')?localStorage.getItem('current user'): localStorage.getItem('client')}</span></dt>
       <dt>Born: <span>18/03/1981</span></dt>
       <dt>Tel: <span>+256775225010</span></dt>
-      <dt>Email: <span>anguamike@yahoo.com</span></dt>
+      <dt>Email: <span id='email'>${(localStorage.getItem('role')=='Client')?localStorage.getItem('current user').replace(' ', '')+'@gmail.com'.toLowerCase(): localStorage.getItem('email')}</span></dt>
     </dl>
     <dl id='address' class='universal'>
       <h4>Client Address</h4>
@@ -27,7 +27,7 @@ document.write(`<div id='main'>
     <dl id='loandetails' class='debit_loan verify_loan view_loan approve_loan View_loan'>
       <h4>Loan Particulars:</h4>
       <dt>Id: <span id='loanid'>1905024</span></dt>
-      <dt>Staus: <span id='status'>Draft</span></dt>
+      <dt>Staus: <span id='status'>${localStorage.getItem('status')}</span></dt>
       <dt>Credit(USD): <span id='cr'>100500</span></dt>
       <dt>Repayment Duration: <span>18 Months</span></dt>
       <dt>Repayment Period: <span>30 Days</span></dt>
@@ -36,11 +36,12 @@ document.write(`<div id='main'>
     </dl><hr>
     <script src='static/scripts/log.js'></script>
     <div class='admin'>
+      <input class='debit_loan' type='text' placeholder='enter amount to debit'></input>
       <button id='rejectuser' class='_red white verify_user' onclick="approve('user verification not done!', 'yellow', 'red')">Reject</button>
       <button id='verify' class='_green white verify_user' onclick="approve('user verified')">Verify</button>
       <button id='reject' class='_red white approve_loan' onclick="approve('loan request rejected', 'red')">Reject</button>
       <button id='approve' class='_green white approve_loan' onclick="approve('loan approved!')">Approve</button>
-      <button id='post' class='_green white debit_loan' onclick="approve('account debited')">Post Payment</button>
+      <button id='post' class='_green white debit_loan' onclick="debit()">Post Payment</button>
     </div>
   </div>
 </div>

--- a/UI/static/scripts/log.js
+++ b/UI/static/scripts/log.js
@@ -1,30 +1,30 @@
 document.write(`
-<h3 class='user debit_loan view_loan'>Loan Transaction Log - Anguandia Mike</h3><hr class='user debit_loan view_loan'>\
+<h3 class='user debit_loan view_loan'>Loan Transaction Log - ${localStorage.getItem('role')=='Client'?localStorage.getItem('current user'): 'Anguandia Mike'}</h3><hr class='user debit_loan view_loan'>\
 <ul id='log' class="list view_loan debit_loan">\
 <li>\
   <span class='blue universal'>Cr:</span>\
   <span>transaction id - 18050630008;</span>\
-  <span class='blue universal'>$30000;</span>\
+  <span class='blue universal pay'></span>\
   <span>date: 15/12/2018</span>\
 </li>\
 <li>\
   <span class='green universal'>Dr:</span>\
   <span>transaction id - 18070230301;</span>\
-  <span class='green universal'>$01000;</span>\
+  <span class='green universal pay'>$01000;</span>\
   <span>date: 30/01/2019</span>\
 </li>\
 <li>\
   <span class='green universal'>Dr:</span>\
   <span>transaction id - 18070630001;</span>\
-  <span class='green universal'>$01200;</span>\
+  <span class='green universal pay'>$01200;</span>\
   <span>date: 28/02/2019</span>\
 </li>\
 <li>\
   <span class='green universal'>Dr:</span>\
   <span>transaction id - 18070630001;</span>\
-  <span class='green universal'>$01000;</span>\
+  <span class='green universal pay'>$01000;</span>\
   <span>date: 31/03/2019</span>\
 </li>\
-<p><span class='blue'>Current Balance: </span><span class='red'>$26800</span></p>
 </ul>\
+<p class='debit_loan view_loan' id='tot'><span>Current Balance: </span><span id='balance'></span></p>
 `);

--- a/UI/static/scripts/template.js
+++ b/UI/static/scripts/template.js
@@ -9,7 +9,7 @@ document.write(
       </div>\
     </header>\
     <nav id='auth'>\
-      <tab class='universal' id='home'><a href='index.html'>Home</a></tab>\
+      <tab class='universal' id='home'><a href= ${localStorage.getItem('role')=='Client'?'home.html':localStorage.getItem('role')=='Admin'?'admin.html': 'home.html'}>Home</a></tab>\
       <tab class='index' id='signin'><a href='signin.html'>Signin</a></tab>\
       <tab class='index' id='signup'><a href='signup.html'>Signup</a></tab>\
       <tab class='user admin' id='signout'><a href='index.html'>Signout</a></tab>\

--- a/UI/static/scripts/user.js
+++ b/UI/static/scripts/user.js
@@ -3,7 +3,7 @@ document.write(`<!--user profile details-->\
 <div id='user_profile'>\
   <div id='picture' class='user admin'>\
     <img src='static/images/Koala.jpg' alt='profile picture' width='100px' height='100px'></img>\
-    <p><span>Anguandia Mike</span></p>\
+    <p><span id='name'>${localStorage.getItem('current user')}</span></p>\
     <button>manage account</button>
   </div>\
 </div>`);

--- a/UI/static/scripts/users.js
+++ b/UI/static/scripts/users.js
@@ -15,105 +15,105 @@ document.write(
       </select>\
     </div><hr>\
     <ul class="list">\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Anguandia Mike</span>\
       <span>18050630007</span></a>\
-      <span>anguamike@yahoo.com</span>\
+      <span class='email'>anguamike@yahoo.com</span>\
       <span class='lightgreen'>Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Benjamin Franklin</span>\
       <span>18070230301</span></a>\
-      <span>benja@gmail.com</span>\
+      <span class='email'>benja@gmail.com</span>\
       <span class='lightgreen'>Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Isaac Asimov</span>\
       <span>18070630001</span></a>\
-      <span>asim@hotmail.com</span>\
+      <span class='email'>asim@hotmail.com</span>\
       <span class='lightgreen'>Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Fadil Rajab</span>\
       <span>18070630001</span></a>\
-      <span>fadhil.rajab@mail.com</span>\
+      <span class='email'>fadhil.rajab@mail.com</span>\
       <span class='lightgreen'>Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Peter Simon</span>\
       <span>18070630001</span></a>\
-      <span>simo@kj.com</span>\
+      <span class='email'>simo@kj.com</span>\
       <span class='green'>Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Famin Pierr</span>\
       <span>10070630001</span></a>\
-      <span>famin@netpipper.com</span>\
+      <span class='email'>famin@netpipper.com</span>\
       <span class='green'>Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Clera Serah</span>\
       <span>12120630001</span></a>\
-      <span>flera@mail.com</span>\
+      <span class='email'>flera@mail.com</span>\
       <span class='red' id='Not Verified'>Not Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Zadoch Simon</span>\
       <span>0807063000</span></a>\
-      <span>zad@mail.com</span>\
+      <span class='email'>zad@mail.com</span>\
       <span class='red' id='Not Verified'>Not Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Os pa mali</span>\
       <span>15070630301</span></a>\
-      <span>ospamil@ymail.com</span>\
+      <span class='email'>ospamil@ymail.com</span>\
       <span class='navy'>Owing</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Bonny Musa</span>\
       <span>17070630001</span></a>\
-      <span>mier@gmail.com</span>\
+      <span class='email'>mier@gmail.com</span>\
       <span class='red' id='Not Verified'>Not Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Tolea Ofin</span>\
       <span>18070630001</span></a>\
-      <span>toto@mail.com</span>\
+      <span class='email'>toto@mail.com</span>\
       <span class='red' id='Not Verified'>Not Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Karim Peter</span>\
       <span>18070230301</span></a>\
-      <span>karim@example.com</span>\
+      <span class='email'>karim@example.com</span>\
       <span class='yellow'>Overdue</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Boran Siraj</span>\
       <span>18070630001</span></a>\
       <span>-----</span>\
       <span class='lightblue'>Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Fiona Paul</span>\
       <span>18070630001</span></a>\
-      <span>kuku200@mail.com</span>\
+      <span class='email'>kuku200@mail.com</span>\
       <span class='lightblue'>Verified</span>\
     </li>\
-    <li>\
+    <li onclick='setClient(this)'>\
       <input type='checkbox'></input>\
       <a href='user.html?a_user_101029=view_User'><span class='name'>Douglas Marie</span>\
       <span>18070630001</span></a>\

--- a/UI/static/styles/main.css
+++ b/UI/static/styles/main.css
@@ -297,8 +297,6 @@ button:active{
     margin-bottom: 0%;
     padding-bottom: 5%;
     border-right: solid 1px lightgrey;
-
-
 }
 
 /* define the user details layout and looks */
@@ -308,6 +306,8 @@ button:active{
     float: right;
     height: 100%;
     position: relative;
+    text-align: center;
+    text-transform: capitalize;
 }
 
 /* give magin to user profile content instead of padding */
@@ -461,7 +461,7 @@ hr{
 }
 
 /* display outsanding balance in red font */
-.red{
+.red, #balance{
     color: red;
 }
 
@@ -587,7 +587,7 @@ hr{
     box-shadow: 2px 2px 15px 5px inset rgb(192, 186, 186);
 }
 
-#loandetail dt{;
+#loandetail dt{
     margin: .2% 0%;
     padding-left: 1%;
 }
@@ -623,4 +623,15 @@ hr{
 
 h1, h3{
     text-transform: capitalize;
+}
+
+/* style email displays */
+.email, #email{
+    text-decoration-line: underline;
+    color: blue;
+}
+
+/* style outstanding balance */
+#tot{
+    color: blue;
 }


### PR DESCRIPTION
Rationalize demo page and item parameter values displayed;
- Save username and type(role )from sign to browser storage
  - Add a null-valued selected select option to role selector to ensure change
  event that trigger session information setting occurs
- Upon successive redirects, retrieve current user credentials to set
page titles, purpose and other loan list or detail fields to harmonize
page content details with account specifics
- Save list item particulars like name and status to browser for
reconstitution when the anchored page is rendered
  - Items in client pages reconstitute their names from the current user
  name while those in admin pages from the saved list item name values
  - Add click listeners to individual list items-loans list(client.js)
  and users list(users.js) to save the current state(name, status and
  email of entry before redirect to the anchored page
  - Add conditional current user role determined reconstitution of entry
  variable values on detail pages
Add simulation of account debit response
  - Add transaction amount input
  - Add real-time transaction logging
  - Add balance computation, and status change if amount posted completes loan
Add parity checks for loan balance amount and status and auto balance
completed loans to show 0 balance on display
Change home page to default profile page for logged in users

To test these changes, explore login as a client and explore every menu
and dashboard item including the home link, note the values displayed
viz-a-viz rational expectations
Then log in as admin and repeat tests