### PR TITLE
Add all loan view feature

### DIFF
--- a/controllers/loanController.js
+++ b/controllers/loanController.js
@@ -16,7 +16,9 @@ exports.create = function(req, res){
 };
 
 // get all, current or repaid loans
-exports.list = function(){};
+exports.list = function(req, res){
+    res.status(200).json({status: 200, data: loans.map(loan => loan.toLoanJson())});
+};
 
 // get specific loan details
 exports.detail = function(){};

--- a/tests/testLoans.js
+++ b/tests/testLoans.js
@@ -106,7 +106,7 @@ describe('test loans', () => {
             it('should not accept repayment if amount paid exceeds current balance')
         });
     });
-    describe.skip('GET /loans', () => {
+    describe('GET /loans', () => {
         // test the get routes
         it("should return an array of all loans", (done) => {
             // test get all when list populated
@@ -122,7 +122,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it('should return a single loan object', (done) => {
+        it.skip('should return a single loan object', (done) => {
             // test get single loan
             let loan_id = 1;
             chai.request(app)
@@ -142,7 +142,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it('should return message loan unavailable', (done) => {
+        it.skip('should return message loan unavailable', (done) => {
             // test get unavailable loan
             let loan_id = 10000;
             chai.request(app)
@@ -154,7 +154,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it('should return all current loans not fully paid', (done) => {
+        it.skip('should return all current loans not fully paid', (done) => {
             //needto create and approve loans
             chai.request(app)
             .get('/loans/?status=approved&repaid=false')
@@ -167,7 +167,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it('should return an empty array if no current loans', (done) => {
+        it.skip('should return an empty array if no current loans', (done) => {
             chai.request(app)
             .get('/loans/?status=approved&repaid=false')
             .end((err, res) => {
@@ -177,7 +177,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it('should return all repaid loans', (done) => {
+        it.skip('should return all repaid loans', (done) => {
             chai.request(app)
             .get('/loans/?status=approved&repaid=true')
             .end((err, res) => {
@@ -190,8 +190,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it('should return repayment history of specified loac',
-        (done) => {
+        it.skip('should return loans repaymnets log', (done) => {
             let loan_id = 1;
             chai.request(app)
             .get(`/loans/${loan_id}/repayments`)


### PR DESCRIPTION
#### Description of Task to be completed?

Achieve target by additions to modules below
- Add target loan availability check and return of appropriate response
if unfound
- Add admin specified status value validity check and appropriate
response if not
- Status update implementation by calling the approve() method of the
target loan with the desired approval status value
- Additionally, add a method-filterRepr(keys) to get the desired
representation of the response object
- Activate approval route related tests in the loan tests' module

#### How should this be manually tested?

To test this feature manually, clone and install a local copy of this
application with npm install command or use the Heroku version. If using
a local copy, your base URL will be http://localhost:3000 while the
Heroku base URL https://quickcredit-anguandia.herokuapp.com
- Create a loan using the endpoint(URL extension) /loans and enter the
loan [body](https://github.com/Anguandia/quickcredit/pull/26) values on
(postman)[]
- Send an approval request using the patch method on endpoint
/loans/1 (the system sequentially assigns loans from 1) and the request body
having status as anything other than approved and rejected. Notice the
status validation message in the response
- Repeat the approval attempt with an id other than 1 and notice the not
found response
- Repeat the same, using id 1 and status either approved or rejected and
notice the response
- Additionally, notice the success response object is a summarized
copy of a full loan object, a testament to the working of the filterRepr()
method
- Also, notice that successful approval will immediately credit the loan
amount and reflect a balance inclusive of interest, not the initial zero
when the loan was created

#### Shortcomings

- In the current state, both approving and rejecting the loan will get
the loan credited with the application amount, a bug to be fixed next
- The credit loan method currently can only be accessed on the approval
route. Will be extricated to full independence in the complete
application

[finishes #165846397 #165845800]