### PR TITLE
Add functionality to view an individual loan

### DIFF
--- a/controllers/loanController.js
+++ b/controllers/loanController.js
@@ -21,7 +21,14 @@ exports.list = function(req, res){
 };
 
 // get specific loan details
-exports.detail = function(){};
+exports.detail = function(req, res){
+    let loan = loans.find(one => one._id == req.params.loanId);
+    if(!loan){
+        res.status(404).json({status: 404, error: `loan with id ${req.params.loanId} does not exist`});
+    } else {
+        res.status(200).json({status: 200, data: loan.toLoanJson()});
+    }
+};
 
 // approve a loan
 exports.approve = function(req, res){

--- a/tests/testLoans.js
+++ b/tests/testLoans.js
@@ -122,7 +122,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it.skip('should return a single loan object', (done) => {
+        it('should return a single loan object', (done) => {
             // test get single loan
             let loan_id = 1;
             chai.request(app)
@@ -142,7 +142,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it.skip('should return message loan unavailable', (done) => {
+        it('should return message loan unavailable', (done) => {
             // test get unavailable loan
             let loan_id = 10000;
             chai.request(app)


### PR DESCRIPTION
#### Tasks to be completed

Add the ability to
- Check loans array by loan id read from the request URL id parameter
- Generate appropriate response if not found
- Return loan object in response as specified in the cahlleenge doc

#### How to manually test this feature

- Clone and install a local copy of this API with npm install or use the
Heroku version
- Using https://quickcredit-anguandia.herokuapp.com for the Heroku
version or http://localhost:3000 for a local version on postman,
  - Create a (post) loan application request using the endpoint /loans
  - Retrieve the created loan with a get request on /loans/1; the
  details should be displayed
  - Change the loan id to 2 ie /loans/2, a not found response should be
  returned

[finishes #165846125]