### PR TITLE
Add functionality to get all current loans

### DIFF
--- a/controllers/loanController.js
+++ b/controllers/loanController.js
@@ -17,7 +17,16 @@ exports.create = function(req, res){
 
 // get all, current or repaid loans
 exports.list = function(req, res){
-    res.status(200).json({status: 200, data: loans.map(loan => loan.toLoanJson())});
+    let selection;
+    if(req.query.status){
+        // convert string status representation inquery to boolean
+        let status = req.query.status=='true'?true: false;
+        selection = loans.filter(one => one.status === req.query.status &
+            one.repaid === status);
+    } else {
+        selection = loans;
+    }
+    res.status(200).json({status: 200, data: selection.map(loan => loan.toLoanJson())});
 };
 
 // get specific loan details

--- a/tests/testLoans.js
+++ b/tests/testLoans.js
@@ -154,7 +154,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it.skip('should return all current loans not fully paid', (done) => {
+        it('should return all current loans not fully paid', (done) => {
             //needto create and approve loans
             chai.request(app)
             .get('/loans/?status=approved&repaid=false')
@@ -167,7 +167,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it.skip('should return an empty array if no current loans', (done) => {
+        it('should return an empty array if no current loans', (done) => {
             chai.request(app)
             .get('/loans/?status=approved&repaid=false')
             .end((err, res) => {


### PR DESCRIPTION
#### Tasks to be accomplished

Modify the list function to check for collection item selection criteria and return a collection of either current or repaid loans alongside the primary role of returning all loans by the following additions;
- Check the incoming request URL for a query string and if available, read collection selection criteria from it else proceed to the primary role of displaying all loans
- Enforce the response array filtering functionality in case of specified array selection criteria to get required collection
- Enable tests for getting current loans

#### How to manually test this feature

On postman with the appropriate base url for either a local or the Heroku copy of this api,
- Create a number of loan applications with post requests on the route base url/loans, each time changing the user email
- Fetch current loans with a get request on base URL/loans?status=approved&repaid=false; the response should contain an empty array
- Approve some of the loans with patch requests on base url/loans/loan id
- Fetch a collection of current loans as above. The response should have an array of the approved loans

#### Pivotal tracker stories

[finishes #165846206 #165846303]