### PR TITLE
Add functionality to view all repaid loans

### DIFF
--- a/tests/testLoans.js
+++ b/tests/testLoans.js
@@ -177,7 +177,7 @@ describe('test loans', () => {
                 done();
             });
         });
-        it.skip('should return all repaid loans', (done) => {
+        it('should return all repaid loans', (done) => {
             chai.request(app)
             .get('/loans/?status=approved&repaid=true')
             .end((err, res) => {


### PR DESCRIPTION
#### Tasks to be completed

- Activate test for getting all repaid loans

#### How to test this feature manually

On postman with the appropriate base URL for either a local or the
Heroku copy of this API,
- Create a number of loan applications with post requests on the route
base URL/loans, each time changing the user email
- Fetch repaid loans with a get request on base
URL/loans?status=approved&repaid=true; the response should contain an
empty array
- Approve some of the loans with patch requests on base URL/loans/loan id
- Fetch repaid loans again as above; still an empty array
- Manually create some loans with repaid as true and status approved
- Fetch a collection of repaid loans as above. The response should have
an array of the repaid loans

#### Problems

The tests for current and repaid loans should not be passing without
creating the specified loans. Need Fixing. Routes working as expected on postman though!

Pivotal tracker stories

[finishes #165846206 #165846303]