### PR TITLE
Add functionality to get all current loans using UI

### DIFF
--- a/challenge4/static/scripts/apply.js
+++ b/challenge4/static/scripts/apply.js
@@ -1,6 +1,5 @@
 /* eslint-disable linebreak-style */
 // loan application page
-const user = document.getElementById('users').value;
 const main = document.createElement('div');
 main.setAttribute('id', 'main');
 main.innerHTML = `<h1 class='loanform'>Loan appliction form</h1><hr>\

--- a/challenge4/static/scripts/main.js
+++ b/challenge4/static/scripts/main.js
@@ -393,6 +393,7 @@ function postLoan() {
           window.location.href = `signup.html?path=auth/signup&${data('loanform')}`;
         }
       } else {
+        console.log(res)
         approve(`${res.error}`, 'yellow', 'red');
       }
     })
@@ -470,6 +471,7 @@ function getLoan(path = query('path')) {
   // elt('list').innerHTML = elt('list') ? "Loading list<span id='load'><span>" : '';
   request(null, path, 'GET')
     .then((res) => {
+      // remove server process wait feedback to pave way for building actual response from server
       if (elt('list')) {
         elt('list').innerHTML = '';
       }
@@ -477,7 +479,8 @@ function getLoan(path = query('path')) {
         if (res.data.constructor === Object) {
           details(res.data, path);
         } else if (res.data.length === 0) {
-          approve(`no ${path}`);
+          let status = collectionResp()[path.slice(path.indexOf('=')+1,)];
+          approve(`no ${status} ${path.slice(0, path.indexOf('?'))}`);
         } else {
           res.data.forEach((loan) => {
             list(loan, path);
@@ -536,7 +539,9 @@ function list(loan, path) {
   const status = document.createElement('span');
   checkbox.type = 'checkbox';
   const para = loan.email || loan.id;
-  content.href = `detail.html?path=${path}/${para}&action=${query('action')}`;
+  // remove query string if available in path query string
+  const endpoint = /=/.test(path) ? path.slice(0, path.indexOf('?')) : path;
+  content.href = `detail.html?path=${endpoint}/${para}&action=${query('action')}`;
   name.name = 'name';
   name.className = 'green';
   status.id = 'status';
@@ -595,4 +600,13 @@ function repayment() {
         elt(item).setAttribute('class', 'navy');
       });
     });
+}
+
+function collectionResp() {
+  resp = {};
+  resp.approved = 'current loans'
+  resp.repaid = 'repaid loans'
+  resp.rejected = 'rejected loans'
+  resp.pending = 'unapproved loans'
+  return resp;
 }


### PR DESCRIPTION
#### What does this PR do?

  Enable the UI to send requests to get all current loans to server and
  render the response (and any such collection as repaid loans)

#### Description of Task to be completed?

  - Tailor response with empty collection array to generate
  request-specific message
  - Build a response object from query status to generalize
  request-specific responses for all collection requests including users
  - Remove query string from path query sting in building detail page
  href for each collection item in the listing

#### How should this be manually tested?

  - Log in to an admin account
  - Click on the current loans' menu item
    A list of all curent loans should be returned or an appropriate
    information of their absence
  - Click on any of the items in the list if not none
    Details of the selected item should be displayed

#### What are the relevant pivotal tracker stories?

  [#166815254 #166825947 #166815319]