### PR TITLE
Add functional links to dashboard tabs

### DIFF
--- a/challenge4/static/scripts/admin.js
+++ b/challenge4/static/scripts/admin.js
@@ -20,13 +20,45 @@ main.innerHTML = `<h1 id='username'>${localStorage.getItem('current user')}</h1>
       </select>\
       </label>
     </div><hr>\
-    <button class='dashboard _yellow green' id='new_user' onclick="loadSelection('Not Verified',  'New Users')"><p>*New Users<span>10</span></p></button>\
-    <button class='dashboard _lightgreen navy' id='Draft' onclick='loadSelection("Draft","", "?a_loan_180524=View_loan")'><p>*New loans<span>${q('newLoans')}</span></p></button>\
-    <button class='dashboard _lightblue navy' id='Verified' onclick='loadSelection("Verified","","?a_loan_180524=View_loan")'><p>Pending Approval<span>${q('newLoans')}</span></p></button>\
-    <button class='dashboard _aliceblue' id='Approved' onclick='loadSelection("Approved", "","?a_loan_180524=View_loan")'><p>Pending Credit<span>${q('pendingCredit')}</span></p></button>\
-    <button class='dashboard _yellow red' id='Rejected' onclick='loadSelection("Rejected", "","?a_loan_180524=View_loan")'><p>Rejected loan applications<span>${q('rejectedLoans')}</span></p></button>\
-    <button class='dashboard _navy white' id='Current' onclick='loadSelection("Current", "","?a_loan_180524=view_loan")'><p>Running loans<span>${q('runningLoans')}</span></p></button>\
-    <button class='dashboard _red white' id='Overdue' onclick='loadSelection("Overdue", "","?a_loan_180524=view_loan")'><p>Loans overdue<span>0</span></p></button>\
-    <button class='dashboard _green white' id='Completed' onclick='loadSelection("Completed", "","?a_loan_180524=view_loan")'><p>Completed<span>${q('completedLoans')}</span></p></button>\
+    <button class='dashboard _yellow green'>
+      <a href='users.html?path=users?status=unverified' class=green>
+        <p>*New Users<span>${q('newUsers')}</span></p>
+      </a>
+    </button>
+    <button class='dashboard _lightgreen navy'>
+      <a href='client.html?path=loans?status=pending&repaid=false' class=navy>
+        <p>*New loans<span>${q('newLoans')}</span></p>
+      </a>
+    </button>
+    <button class='dashboard _lightblue navy'>
+      <a href='client.html?path=loans?status=pending&repaid=false&balance=0' class=navy>
+        <p>Pending Approval<span>${q('newLoans')}</span></p>
+      </a>
+    </button>
+    <button class='dashboard _aliceblue'>
+      <a href='client.html?path=loans?status=approved&repaid=false&balance=0'>
+        <p>Pending Credit<span>${q('pendingCredit')}</span></p>
+      </a>
+    </button>
+    <button class='dashboard _yellow red'>
+      <a href='client.html?path=loans?status=rejected' class=red>
+        <p>Rejected loan applications<span>${q('rejectedLoans')}</span></p>
+      </a>
+    </button>
+    <button class='dashboard _navy white'>
+      <a href='client.html?path=loans?status=approved&repaid=false' class='white'>
+        <p>Running loans<span>${q('runningLoans')}</span></p>
+      </a>
+    </button>
+    <button class='dashboard _red white'>
+      <a href='client.html?path=loans?status=overdue&repaid=false' class='white'>
+        <p>Loans overdue<span>0</span></p>
+      </a>
+    </button>
+    <button class='dashboard _green white'>
+      <a href='client.html?path=loans?status=repaid' class='white'>
+        <p>Completed<span>${q('completedLoans')}</span></p>
+      </a>
+    </button>
     </div>`;
 document.body.appendChild(main);

--- a/challenge4/static/scripts/client.js
+++ b/challenge4/static/scripts/client.js
@@ -27,7 +27,6 @@ placeholder="enter loan id to search">\
   </select>\
   </label>
 </div><hr>\
-<ul class="list" id='list' onmouseover='showTip(this, "click on the name or id of a loan entry to select", "-10%")'>\
-</ul>\
+<ul class="list" id='list'></ul>\
 </div>`;
 document.body.appendChild(main);

--- a/challenge4/static/scripts/home.js
+++ b/challenge4/static/scripts/home.js
@@ -4,7 +4,15 @@ main.setAttribute('id', 'main');
 main.innerHTML = `<h1 id='username'>${localStorage.getItem('current user')}</h1><hr>\
     <div id="main_main">\
     <h3 class='home'>${localStorage.getItem('current user')}-Personal Dashboard</h3><hr>\
-    <button class='dashboard _lightgreen navy' id='Draft' onclick='loadOwn()'><p><a href=detail.html?u_loan_180524=view_loan style='text-decoration:none; color:navy'>*Current loan: <span>${localStorage.getItem('currentLoan')}</span></a></p></button>\
-    <button class='dashboard _green white' id='Completed' onclick='loadOwnHistory()'><p>Completed: <span id='complete_loans'>${localStorage.getItem('history')}</span></p></button>\
+    <a href='client.html?path=loans?status=approved&email=${localStorage.getItem('email')}'>\
+      <button class='dashboard _lightgreen navy'>\
+        <p class='navy'>*Current loan: <span>${localStorage.getItem('currentLoan')}</span></p>\
+      </button>\
+    </a>\
+    <a href='client.html?path=loans?status=repaid&email=${localStorage.getItem('email')}&repaid=true'>\
+      <button class='dashboard _green white'>\
+        <p>Completed: <span id='complete_loans'>${localStorage.getItem('history')}</span></p>\
+      </button>\
+    </a>\
     </div>`;
 document.body.appendChild(main);

--- a/challenge4/static/scripts/template.js
+++ b/challenge4/static/scripts/template.js
@@ -40,8 +40,8 @@ document.body.innerHTML = `<header>\
         <a href='client.html?path=loans' class='admin'>Loan details</a>\
         <a href='client.html?path=loans&action=approve' class='admin'>Approve loan</a>\
         <a href='client.html?path=loans&action=repayment' class='admin'>Debit loan</a>\
-        <a href='users.html' class='admin'>Clients</a>\
-        <a href='users.html' class='admin'>Client Details</a>\
+        <a href='users.html?path=users' class='admin'>Clients</a>\
+        <a href='users.html?path=users' class='admin'>Client Details</a>\
         <a href='users.html?path=users&action=verify' class='admin'>Verify Client</a>\
         <a href='users.html?path=users&action=upgrade' class='admin'>Upgrade user to admin</a>\
       </div>\

--- a/challenge4/static/styles/main.css
+++ b/challenge4/static/styles/main.css
@@ -762,7 +762,7 @@ button:focus{
     width: 98%;
     text-indent: 2%;
 }
-#loande
+
 #signout{
     display: none;
 }
@@ -845,4 +845,8 @@ button:focus{
      50%{margin-left: 5%; background-color: green}
      75%{margin-left: 7.5%; background-color: rebeccapurple}
      100%{margin-left: 10%; background-color: yellow}
+}
+
+a {
+    text-decoration: none
 }

--- a/challenge4/users.html
+++ b/challenge4/users.html
@@ -7,7 +7,7 @@
     <link href="static/styles/media.css", rel="stylesheet", type="text/css">
   </head>
   <!--onload function selects elements applicable to home page from template elements-->
-  <body id='loanapprove' onload = "getLoan('users')">
+  <body id='loanapprove' onload = "getLoan()">
     <!--the page template dynamically written from script indicated-->
     <script src='static/scripts/template.js'></script>
     <!--page specific content written from script indicated-->


### PR DESCRIPTION
#### What does this PR do?

  Enable collections represented by dashboard tabs to be fetched on
  click of individual tabs on UI

#### Description of Task to be completed?

  - Add anchor links with respective fetch request paths to dashboard
  tabs
  - Remove commented out code from client.js include file
  - Factor in different collections in the collection response object,
  collectionResp in the main script file
  - Update main css file to take account of changes in html file
  structures

#### How should this be manually tested?

  - Sign in as admin or client
  - Click on any of the tabs on the dashboard; the represented
  collection should be returned

#### What are the relevant pivotal tracker stories?

 [finishes #166825947]